### PR TITLE
chore: ios podspec NMapsMap 버전 명시 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nmap",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
     "ios/Frameworks/**",
     "react-native-nmap.podspec",
     "android/**"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
     "react-native-nmap.podspec",
     "android/**"
   ],
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@1.22.22"
 }

--- a/react-native-nmap.podspec
+++ b/react-native-nmap.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
 
   s.static_framework = true
   s.dependency 'React'
-  s.dependency 'NMapsMap', '~> 3.16.1'
+  s.dependency 'NMapsMap'
 
 end


### PR DESCRIPTION
기존의 NMapsMap 3.16.2가 legacy로 바뀌어 새 버전을 사용하기 위해 버전 명시를 제거 하였습니다